### PR TITLE
Space before differentials

### DIFF
--- a/src/lib/AsciiMath.hs
+++ b/src/lib/AsciiMath.hs
@@ -7,11 +7,11 @@ import Exception                     (AsciimathException(ErrorAndSource)
                                      ,printAndExit,renderError)
 import Lexer                         (get_tokens)
 import Parser                        (parseAscii)
-import Passes                        (matrix)
+import Passes                        (passes)
 import TeXWriter                     (writeTeX)
 
 readAscii :: String -> Either AsciimathException Code
-readAscii s = return . matrix =<< parseAscii =<< get_tokens s
+readAscii s = return . passes =<< parseAscii =<< get_tokens s
 
 compile :: String -> Either AsciimathException String
 compile s = fmap writeTeX $ readAscii s

--- a/src/lib/Passes.hs
+++ b/src/lib/Passes.hs
@@ -1,17 +1,32 @@
 {-# LANGUAGE LambdaCase #-}
-module Passes (matrix) where
+module Passes (passes,needsSpace,prependSpace) where
+import Data.Bool (bool)
 import Data.List.Split (splitWhen)
-import Ast (Constant(Ampersand,DoubleSemicolon)
-           ,Code,Expr(Simple),SimpleExpr(SEConst,Matrix),walkC)
+import Ast (Constant(..),Code,Expr(..),SimpleExpr(..),walkC)
+
+passes :: Code -> Code
+passes = walkC prependSpace . walkC matrix
 
 matrix :: Code -> Code
-matrix = walkC $ \es -> case map cols $ rows es of
-                          [[code]] -> code
-                          x -> [Simple $ Matrix x]
+matrix es = case map cols $ rows es of
+              [[code]] -> code
+              x -> [Simple $ Matrix x]
     where rows = splitWhen $ isConstant DoubleSemicolon
           cols = splitWhen $ isConstant Ampersand
 
 isConstant :: Constant -> Expr -> Bool
 isConstant c = \case
     Simple (SEConst x) | c == x -> True
+    _ -> False
+
+prependSpace :: Code -> Code
+prependSpace [] = []
+prependSpace (x:xs) = x : concatMap go xs
+    where go :: Expr -> [Expr]
+          go e = bool (<> [Simple (SEConst Space)]) id (needsSpace e) [e]
+
+needsSpace :: Expr -> Bool
+needsSpace = \case
+    -- Differentials; e.g. dx, dA
+    (Simple (SEConst (Letters ('d':_:[])))) -> True
     _ -> False

--- a/src/lib/Passes.hs
+++ b/src/lib/Passes.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 module Passes (passes,needsSpace,prependSpace) where
 import Data.Bool (bool)
+import Data.List (isPrefixOf)
 import Data.List.Split (splitWhen)
 import Ast (Constant(..),Code,Expr(..),SimpleExpr(..),walkC)
 
@@ -23,10 +24,10 @@ prependSpace :: Code -> Code
 prependSpace [] = []
 prependSpace (x:xs) = x : concatMap go xs
     where go :: Expr -> [Expr]
-          go e = bool (<> [Simple (SEConst Space)]) id (needsSpace e) [e]
+          go e = bool id (Simple (SEConst Space) :) (needsSpace e) [e]
 
 needsSpace :: Expr -> Bool
 needsSpace = \case
     -- Differentials; e.g. dx, dA
-    (Simple (SEConst (Letters ('d':_:[])))) -> True
+    (Simple (SEConst (Letters s))) | "d" `isPrefixOf` s -> True
     _ -> False

--- a/tests/spec/misc-sym.latex
+++ b/tests/spec/misc-sym.latex
@@ -1,5 +1,8 @@
 # Miscellaneous symbols
 \int 
+# https://github.com/alexander-c-b/AsciiMath/issues/11
+\int x\ dx+\int y\ dy
+1+\frac{dx}{dy}=1
 \oint 
 \partial 
 \nabla 

--- a/tests/spec/misc-sym.txt
+++ b/tests/spec/misc-sym.txt
@@ -1,4 +1,7 @@
 int
+# https://github.com/alexander-c-b/AsciiMath/issues/11
+int x dx + int y dy
+1 + dx/dy = 1
 oint
 del
 grad


### PR DESCRIPTION
Resolves #10.

This adds a space before any constant term like "dx"; i.e., a "d" followed by any other letter.
